### PR TITLE
Document current implementation in gherkin

### DIFF
--- a/features/knowledge_gaps.feature
+++ b/features/knowledge_gaps.feature
@@ -1,0 +1,48 @@
+# 4. Identify knowledge gaps.
+# Use CLI -> initiate the process by selecting a topic ->
+# it then uses embeddings and OpenAI to select unanswered questions about that topic ->
+# unanswered questions are posted to specific slack channel -> users can answer them in threads ->
+# bookmarked conversations are uploaded to Confluence (dedicated space).
+
+# Ask NOT DX question ("What power superman has?").
+# Wait for answer in thread.
+# TA should answer that it has no context about it.
+# Check qa_interactions table about this question exists.
+
+# Go to MAIN console menu:
+
+# press 3 (Create a vector db for interactions)
+# check that all rows in qa_interactions table have last_embeded and embed filled in.
+
+# Go to MAIN console menu:
+
+# press 5 (Identify knowledge gaps)
+# enter "superman"
+# TA should post a message in topassist-dev-knowledge-gap channel
+# check that quiz_questions last row has a thread_id
+
+# Use white_check_mark emoji on TA message
+# check that user in user_scores table appears and has filled luminary_score eq 1
+
+Feature: Knowledge gaps
+
+  Scenario: TopAssist initiates conversations for unanswered questions
+    Given databases contain documents with associated embeddings:
+      | title           | contents                                                  |
+      | Holiday Policy  | Full time employees are eligible for 30 days of per year. |
+      | Hardware Policy | Company hardware cannot be used for personal purposes.    |
+    When I submit phrase: "What power superman has?"
+    Then listener asks OpenAI for embeddings for the given phrase
+    And corresponding documents are not found in the database
+    And question "What power superman has?" is saved as unanswered
+    And I get rewarded 1 revealer point
+    When I run CLI command "main.py knowledge-gap superman"
+    Then listener asks OpenAI for embeddings for the given phrase
+    And unanswered questions for given embeddings are found:
+      | question                 |
+      | What power superman has? |
+    And thread "What power superman has?" is created in #topassist-dev-knowledge-gap channel
+    When I reply in the thread with: "Flying"
+    And I react to that reply with :white_check_mark:
+    Then conversation is being uploaded to dedicated confluence space
+    And I am awarded 1 luminary point

--- a/features/populate_knowledge_base.feature
+++ b/features/populate_knowledge_base.feature
@@ -1,0 +1,18 @@
+# 1. Populate knowledge base.
+#   Use CLI -> fetch from Confluence (pages with all the comments)
+#    -> SQL -> OpenAI generate embeddings -> vector db
+
+Feature: Populate knowledge base
+
+  Scenario: CLI commands invocation pulls data from Confluence and saves it in vector database
+    Given Confluence stubs are defined:
+      | space | page title      | page contents |
+      | IT    | Hardware Policy | Company hardware cannot be used for personal purposes.    |
+      | HR    | Holiday Policy  | Full time employees are eligible for 30 days of per year. |
+    When I run CLI command "main.py import --space HR"
+    Then Confluence documents are stored in SQL database
+      | title          |
+      | Holiday Policy |
+    And binary document representations are stored in vector database
+      | title           | embeddings      |
+      | Holiday Policy  | <format t.b.d.> |

--- a/features/slack_conversation.feature
+++ b/features/slack_conversation.feature
@@ -1,0 +1,33 @@
+Feature: Slack conversation
+
+# 2. Q&A.
+#   User posts a message to slack channel the bot is invited to.
+#   Slack listener receives the event -> detects if it is a question (if it has ? at the end) ->
+#   generates embedding for the question (using OpenAI) -> retrieves most relevant documents from vector database ->
+#   builds a message that includes content of relevant pages + user’s question ->
+#   creates a conversation with Open AI (thread in an assistant) -> wait for a response ->
+#   post to Slack as a response (in a thread) -> store it in database (including association between assistant thread id and slack thread id)
+# 3. Feedback. User posts a message to a thread started from the original question -> same as Q&A but instead of creating new conversation it posts to an exiting one.
+
+  Scenario: User interacts with TopAssist in Slack
+    Given databases contain documents with associated embeddings:
+      | title           | contents                                                  |
+      | Holiday Policy  | Full time employees are eligible for 30 days of per year. |
+      | Hardware Policy | Company hardware cannot be used for personal purposes.    |
+    When I submit phrase: "Totally not a question"
+    Then listener  does not react
+    When I submit phrase: "How many days off am I eligible for?"
+    Then listener asks OpenAI for embeddings for the given phrase
+    And corresponding documents are found in the database
+    And listener asks OpenAI for answer providing it with
+      | question                             | documents                                                 |
+      | How many days off am I eligible for? | Full time employees are eligible for 30 days of per year. |
+    And this reply is posted in Slack thread: "You are eligible for 30 days off"
+    And the reply is saved in the database
+    When I submit phrase "Why only 30?"
+    Then listener asks OpenAI for embeddings for the given phrase
+    And corresponding documents are found in the database
+    And listener asks OpenAI for answer providing it with
+      | question     | documents                                                 |
+      | Why only 30? | Full time employees are eligible for 30 days of per year. |
+    And this reply is posted in Slack thread: "That's what's company's Holiday Policy says"


### PR DESCRIPTION
Main use cases to be covered (from pairing session with with @id-ilych)

> 1. Populate knowledge base. Use CLI -> fetch from Confluence (pages with all the comments) -> SQL -> OpenAI generate embeddings -> vector db
> 2. Q&A. User posts a message to slack channel the bot is invited to. Slack listener receives the event -> detects if it is a question (if it has ? at the end) -> generates embedding for the question (using OpenAI) -> retrieves most relevant documents from vector database -> builds a message that includes content of relevant pages + user’s question -> creates a conversation with Open AI (thread in an assistant) -> wait for a response -> post to Slack as a response (in a thread) -> store it in database (including association between assistant thread id and slack thread id)
> 3. Feedback. User posts a message to a thread started from the original question -> same as Q&A but instead of creating new conversation it posts to an exiting one.
> 4. Identify knowledge gaps. Use CLI -> initiate the process by selecting a topic -> it then uses embeddings and OpenAI to select unanswered questions about that topic -> unanswered questions are posted to specific slack channel -> users can answer them in threads -> bookmarked conversations are uploaded to Confluence (dedicated space).
> 5. Gamification (cross-concern). Asking questions rewarded with seeker points. When you question was unanswered you get revealer points during knowledge gap discovery. Luminary points are given to those who answer knowledge gap questions